### PR TITLE
Update README to reflect the WG/CG process

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Please note that the Community Group is farily new, so the following list is not
 
 * AssemblyScript DevX -- discussing missing language features and they way to implement them. Also we discuss the various approaches to interfacing AssemblyScript modules with the platform, e.g. do we choose eDSL or meta-programming approach;
 * AssemblyScript libraries -- since we cannot import TypeScript libraries, common libraries like serialization, math, etc need to be reimplemented;
-* AssemblyScript compiler
+* AssemblyScript compiler hooks -- unlike Rust AssemblyScript does not have macros that would allow implementing basic code transformations that are important for eDSL or meta-programming. Many of these hooks are pretty common to most projects.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,34 @@
-# AssemblyScript Community Group
-> TODO: This repo to be moved to a collectively owned organization, e.g. https://github.com/AssemblyScript
+![](https://avatars1.githubusercontent.com/u/28916798?s=64) AssemblyScript Community Group
+=================
 
-Majority of the projects in this community group are platforms/runtimes that allow other third-party developers to develop, deploy, and execute modules written in AssemblyScript. This includes both trustful and trustless platforms. This repository with its PRs and issues is used to coordinate these projects on common components and discussions.
+The Community Group provides all interested parties a place to discuss and collaborate with other community members.
 
-### Goals
+**Related**
 
-* As a community, we want to discuss and priotize missing language features that we then would communicate to the core developers of AssemblyScript;
-* We want to avoid duplicating effort of writing common AssemblyScript components like libraries and compiler hooks;
-* We want to have shared responsibility for security-critical components of AssemblyScript.
+* [AssemblyScript Compiler](https://github.com/AssemblyScript/assemblyscript)
+* [AssemblyScript Working Group](https://github.com/AssemblyScript/working-group)
 
-### Common Topics
+**Contents**
+
+* [Goals](#goals)
+* [Guidelines](#guidelines)
+* [Topics](#topics)
+
+# Goals
+
+* Enable everyone to share their ideas and projects
+* Communicate core feature requests and use cases to aid in prioritizing the Working Group's efforts
+* Avoid duplicating efforts amongst the broader ecosystem
+
+# Guidelines
+
+* Everyone working on or with AssemblyScript is welcome to participate!
+* All participants must adhere to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+# Topics
+
+Please note that the Community Group is farily new, so the following list is not exclusive. At this point in time, the majority of projects are platforms/runtimes that allow other third-party developers to develop, deploy, and execute modules written in AssemblyScript. This includes both trustful and trustless platforms.
 
 * AssemblyScript DevX -- discussing missing language features and they way to implement them. Also we discuss the various approaches to interfacing AssemblyScript modules with the platform, e.g. do we choose eDSL or meta-programming approach;
 * AssemblyScript libraries -- since we cannot import TypeScript libraries, common libraries like serialization, math, etc need to be reimplemented;
-* AssemblyScript compiler hooks -- unlike Rust AssemblyScript does not have macros that would allow implementing basic code transformations that are important for eDSL or meta-programming. Many of these hooks are pretty common to most projects.
+* AssemblyScript compiler


### PR DESCRIPTION
Gets the CG README in line with the WG's. Mostly layout and formatting, plus a few words that we welcome everyone. Also copies the Code of Conduct from the WG.